### PR TITLE
Modify params to accomodate v3.0 of api specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,61 @@ $ rake delete_druids RAILS_ENV=production file=druid_list.txt
 ### Delete a single druid
 
 $ rake delete RAILS_ENV=production druid=oo000oo0001
+
+# HTTP API
+
+### Items
+
+#### `/items/:druid`
+
+`DELETE /items/:druid`
+
+##### Summary
+Deletes a druid from all registered subtargets.
+
+##### Parameters
+Name | Located In | Description | Required | Schema | Default
+---- | ---------- | ----------- | -------- | ------ | -------
+`druid` | url | object identifier | yes | String |
+
+##### Responses
+Code | Description
+---- | -----------
+`200` | Request received and successfully processed for all subtargets
+`202` | Request received but did not complete successfully (one or more subtargets may have not been deleted)
+
+#### `/items/:druid/subtargets/:subtarget`
+
+`DELETE /items/:druid/subtargets/:subtarget`
+
+##### Summary
+Deletes a druid from a specific subtarget.
+
+##### Parameters
+Name | Located In | Description | Required | Schema | Default
+---- | ---------- | ----------- | -------- | ------ | -------
+`druid` | url | object identifier | yes | String |
+`subtarget` | url | subtarget name (usually capitialized) | yes | String |
+
+##### Responses
+Code | Description
+---- | -----------
+`200` | Request received and successfully processed for subtarget
+`202` | Request received but did not complete successfully
+
+`PATCH/PUT /items/:druid/subtargets/:subtarget`
+
+##### Summary
+Indexes a druid from a specific subtarget.
+
+##### Parameters
+Name | Located In | Description | Required | Schema | Default
+---- | ---------- | ----------- | -------- | ------ | -------
+`druid` | url | object identifier | yes | String |
+`subtarget` | url | subtarget name (usually capitialized) | yes | String |
+
+##### Responses
+Code | Description
+---- | -----------
+`200` | Request received and successfully processed for subtarget
+`202` | Request received but did not complete successfully

--- a/app/controllers/base_indexer/application_controller.rb
+++ b/app/controllers/base_indexer/application_controller.rb
@@ -1,6 +1,5 @@
 module BaseIndexer
   class ApplicationController < ActionController::Base
-    respond_to :json, :xml, :html
 
     def remove_prefix(druid)
       druid.gsub('druid:', '') # lop off druid prefix if sent

--- a/base_indexer.gemspec
+++ b/base_indexer.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'sqlite3'
 
-  s.add_development_dependency 'rspec', '~> 3.1.0' # bug with graph_spec #remove_predicate_and_its_object_statements for 3.2.0
-  s.add_development_dependency 'rspec-rails', '~> 3.1.0' # bug with graph_spec #remove_predicate_and_its_object_statements for 3.2.0
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,13 @@ BaseIndexer::Engine.routes.draw do
   get 'about/version' => 'about#version'
   get 'about' => 'about#version'
 
-  resources :items, only: [:update, :destroy]
+  resources :items, only: [:destroy], param: :druid, default: { format: :json } do
+    member do
+      patch 'subtargets/:subtarget', action: :update
+      put 'subtargets/:subtarget', action: :update
+      delete 'subtargets/:subtarget', action: :destroy
+    end
+  end
+
   resources :collections, only: :update
 end

--- a/spec/controllers/base_indexer/items_controller_spec.rb
+++ b/spec/controllers/base_indexer/items_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe BaseIndexer::ItemsController, type: :controller do
+  let(:my_instance) { instance_double(BaseIndexer::MainIndexerEngine) }
+  before do
+    allow(BaseIndexer::MainIndexerEngine).to receive(:new).and_return(my_instance)
+  end
+  describe 'PATCH/PUT update' do
+    it 'creates an indexing job' do
+      expect(my_instance).to receive(:index).with('bb1111cc2222', 'SEARCHWORKS' => true)
+      patch :update, druid: 'druid:bb1111cc2222', subtarget: 'SEARCHWORKS', use_route: :base_indexer
+      expect(response.status).to eq 200
+    end
+    it 'when something bad happens return a 202' do
+      expect(my_instance).to receive(:index).with('bb1111cc2222', 'SEARCHWORKS' => true).and_raise(StandardError)
+      patch :update, druid: 'druid:bb1111cc2222', subtarget: 'SEARCHWORKS', use_route: :base_indexer
+      expect(response.status).to eq 202
+    end
+  end
+  describe 'DELETE destroy' do
+    context 'with a subtarget' do
+      it 'sends an "#index" with a false to the IndexerEngine' do
+        expect(my_instance).to receive(:index).with('bb1111cc2222', 'SEARCHWORKS' => false)
+        delete :destroy, druid: 'druid:bb1111cc2222', subtarget: 'SEARCHWORKS', use_route: :base_indexer
+        expect(response.status).to eq 200
+      end
+    end
+    context 'without a subtarget' do
+      it 'sends a "#delete" to the IndexerEngine' do
+        expect(my_instance).to receive(:delete).with('bb1111cc2222')
+        delete :destroy, druid: 'druid:bb1111cc2222', use_route: :base_indexer
+        expect(response.status).to eq 200
+      end
+    end
+  end
+end


### PR DESCRIPTION
Most of this work was discussed and defined in https://github.com/sul-dlss/discovery-indexing/issues/9

Merging this PR does introduce non-backwards compatible changes including:
 - changes to the `ItemsController` more about that in 890b143

The breaking changes would also close #23 as that functionality would no longer be working.