### PR TITLE
remove is_it_working-cbeer gem

### DIFF
--- a/base_indexer.gemspec
+++ b/base_indexer.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 4'
   s.add_dependency 'discovery-indexer', '~> 2.0.0'
   s.add_dependency 'retries'
-  s.add_dependency 'is_it_working-cbeer'
   s.add_dependency 'dor-fetcher'
 
   s.add_development_dependency 'sqlite3'

--- a/config/initializers/is_it_working.rb
+++ b/config/initializers/is_it_working.rb
@@ -1,3 +1,0 @@
-require 'is_it_working'
-Rails.configuration.middleware.use(IsItWorking::Handler) do |_h|
-end


### PR DESCRIPTION
This PR fixes #47 . We decided that any status monitoring should be done by the application at its level and not within the base_indexer gem.