### PR TITLE
loosen up discovery-indexer requirements

### DIFF
--- a/base_indexer.gemspec
+++ b/base_indexer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   # s.test_files = Dir["test/**/*"]
   # s.test_files = Dir["spec/**/*"]
   s.add_dependency 'rails', '~> 4'
-  s.add_dependency 'discovery-indexer', '~> 2.0.0'
+  s.add_dependency 'discovery-indexer', '>= 2', '<= 4.0'
   s.add_dependency 'retries'
   s.add_dependency 'dor-fetcher'
 


### PR DESCRIPTION
Closes #46 , v3.0.0 or discovery-indexer now won't fail on missing RDF things.